### PR TITLE
Fix script errors in GAMIVAL

### DIFF
--- a/demo_compute_CNN_feats.py
+++ b/demo_compute_CNN_feats.py
@@ -15,13 +15,14 @@ import scipy.io
 import math
 import time
 
-def test_video(NDGmodel, videopath, videoname, framerate):    
-    probe = ffmpeg.probe(videoname ) 
+def test_video(NDGmodel, videopath, videoname, framerate):
+    filepath = os.path.join(videopath, videoname)
+    probe = ffmpeg.probe(filepath)
     video_info = next(x for x in probe['streams'] if x['codec_type'] == 'video')
     width = int(video_info['width'])
     height = int(video_info['height'])
     out, err = (ffmpeg
-                .input(videoname)
+                .input(filepath)
                 .output('pipe:', format='rawvideo', pix_fmt = 'rgb24')
                 .run(capture_stdout = True)
                 )
@@ -66,13 +67,15 @@ if __name__== "__main__":
     
     parser.add_argument('-mp', '--model', action='store', dest='model', default=r'./models/subjectiveDemo2_DMOS_Final.model' ,
                     help='Specify model together with the path, e.g. ./models/subjectiveDemo2_DMOS_Final.model')
+    parser.add_argument('--video_path', type=str, default='.',
+                    help='Directory containing the input videos.')
     
     args = parser.parse_args()
     
     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'#cpu only
 
     csv_file = os.path.join('mos_files', args.dataset_name+'_metadata.csv')
-    df = pandas.read_csv(csv_file)
+    df = pd.read_csv(csv_file)
     videoname = df['File'].to_numpy()
     framerate = df['framerate'].to_numpy()
     feature_patch_total = []
@@ -83,10 +86,10 @@ if __name__== "__main__":
     NDGmodel = tf.keras.Model(inputs = NDGmodel.input, outputs = x)
     for i in range(len(videoname)):
         t_overall_start = time.time()
-        feature_patch, feats_frame_patch = test_video(NDGmodel, values.videopath, videoname[i], framerate[i])
+        feature_patch, feats_frame_patch = test_video(NDGmodel, args.video_path, videoname[i], framerate[i])
         feature_patch_total.append(feature_patch)
         feats_frame_patch_total[i,0] = feats_frame_patch
         print('Overall {} secs lapsed..'.format(time.time() - t_overall_start))
-        scipy.io.savemat('feats_mat/LIVE-Meta-Mobile-Cloud-Gaming_CNN_bicubic_feats.mat', mdict={'feats_mat': np.asarray(feature_patch_total,dtype=np.float)})
+        scipy.io.savemat('feat_files/LIVE-Meta-Mobile-Cloud-Gaming_CNN_bicubic_feats.mat', mdict={'feats_mat': np.asarray(feature_patch_total,dtype=np.float)})
     
     #scipy.io.savemat('feats_files/LIVE-Meta-Mobile-Cloud-Gaming_CNN_bicubic_feats_frame.mat', mdict={'feats_mat_frames': np.asarray(feats_frame_patch_total,dtype=np.object)})

--- a/evaluate_bvqa_features_regression.py
+++ b/evaluate_bvqa_features_regression.py
@@ -312,7 +312,7 @@ def main(args):
   dir_path = os.path.dirname(args.best_parameter)
   if not os.path.exists(dir_path):
     os.makedirs(dir_path)
-  scipy.io.savemat(args.best_parameter+'_'+args.num_iterations+'iter.mat', 
+  scipy.io.savemat(args.best_parameter+'_'+str(args.num_iterations)+'iter.mat',
       mdict={'best_parameters': np.asarray(best_parameters,dtype=object)})
 
 if __name__ == '__main__':

--- a/run_all_bvqa_regression.sh
+++ b/run_all_bvqa_regression.sh
@@ -27,7 +27,7 @@ for FOLDER in "${FOLDERS[@]}"
 do
 
   feature_file=feat_files/${DS}_${m}_feats.mat
-  out_file=result/$${DS}_${m}
+  out_file=result/${DS}_${m}
   predicted_score=pre_score/${DS}_${m}_predicted_score.mat
   best_pamtr=best_pamtr/${DS}_${m}_pamtr.mat
   log_file=logs/${DS}_regression.log


### PR DESCRIPTION
## Summary
- add a `--video_path` option for CNN feature extraction
- correct pandas usage and file paths in `demo_compute_CNN_feats.py`
- fix concatenation bug in regression evaluation
- correct output path in run script

## Testing
- `python -m py_compile demo_compute_CNN_feats.py evaluate_bvqa_features_regression.py`
- `bash -n run_all_bvqa_regression.sh`

------
https://chatgpt.com/codex/tasks/task_e_68499eb210a0832db3493a176e421dbf